### PR TITLE
Add hysteresis to voltage warning to prevent flickering

### DIFF
--- a/lib/src/widgets/navigation/footer.dart
+++ b/lib/src/widgets/navigation/footer.dart
@@ -100,6 +100,7 @@ class _VoltageWarningState extends State<VoltageWarning>
   late AnimationController controller;
   late Animation<Color?> colorAnimation;
 
+  bool _isShowing = false;
   static const double warningVoltage = 21;
   static const double criticalVoltage = 20;
 
@@ -134,20 +135,32 @@ class _VoltageWarningState extends State<VoltageWarning>
   }
 
   void checkVoltage() {
-    if (!mounted) return;
+  if (!mounted) return;
 
-    if (!widget.model.isConnected || !isLow) {
-      controller.stop();
-      controller.reset();
-      return;
-    }
-
-    updateAnimation();
-
-    if (!controller.isAnimating) {
-      controller.repeat(reverse: true);
-    }
+  final voltage = widget.model.driveMetrics.batteryVoltage;
+  
+  // Turn on when below threshold
+  if (voltage < warningVoltage && voltage > 0) {
+    _isShowing = true;
   }
+  
+  // Turn off when 0.5V above threshold (prevents flickering)
+  if (voltage > warningVoltage + 0.5 || voltage == 0) {
+    _isShowing = false;
+  }
+
+  if (!widget.model.isConnected || !_isShowing) {
+    controller.stop();
+    controller.reset();
+    return;
+  }
+
+  updateAnimation();
+
+  if (!controller.isAnimating) {
+    controller.repeat(reverse: true);
+  }
+}
 
   @override
   void dispose() {
@@ -167,7 +180,7 @@ class _VoltageWarningState extends State<VoltageWarning>
   @override
   Widget build(BuildContext context) {
     final voltage = widget.model.driveMetrics.batteryVoltage;
-    if (!isLow || voltage == 0) return const SizedBox.shrink();
+    if (!_isShowing) return const SizedBox.shrink();
 
     return AnimatedBuilder(
       animation: controller,

--- a/lib/src/widgets/navigation/footer.dart
+++ b/lib/src/widgets/navigation/footer.dart
@@ -101,12 +101,10 @@ class _VoltageWarningState extends State<VoltageWarning>
   late Animation<Color?> colorAnimation;
 
   bool _isShowing = false;
+  bool _isCritical = false;
+
   static const double warningVoltage = 21;
   static const double criticalVoltage = 20;
-
-  bool get isLow => widget.model.driveMetrics.batteryVoltage < warningVoltage;
-  bool get isCritical =>
-      widget.model.driveMetrics.batteryVoltage < criticalVoltage;
 
   @override
   void initState() {
@@ -121,7 +119,7 @@ class _VoltageWarningState extends State<VoltageWarning>
   }
 
   void updateAnimation() {
-    if (isCritical) {
+    if (_isCritical) {
       colorAnimation = ColorTween(
         begin: Colors.red.shade900,
         end: Colors.red.shade700,
@@ -139,14 +137,24 @@ class _VoltageWarningState extends State<VoltageWarning>
 
   final voltage = widget.model.driveMetrics.batteryVoltage;
   
-  // Turn on when below threshold
+  // Turn on warning when below threshold
   if (voltage < warningVoltage && voltage > 0) {
     _isShowing = true;
   }
   
-  // Turn off when 0.5V above threshold (prevents flickering)
+  // Turn off warning when 0.5V above threshold
   if (voltage > warningVoltage + 0.5 || voltage == 0) {
     _isShowing = false;
+  }
+
+  // Turn on critical when below threshold
+  if (voltage < criticalVoltage && voltage > 0) {
+    _isCritical = true;
+  }
+  
+  // Turn off critical when 0.5V above threshold
+  if (voltage > criticalVoltage + 0.5) {
+    _isCritical = false;
   }
 
   if (!widget.model.isConnected || !_isShowing) {
@@ -170,7 +178,7 @@ class _VoltageWarningState extends State<VoltageWarning>
   }
 
   String getWarningMessage(double voltage) {
-    if (voltage < criticalVoltage) {
+    if (_isCritical) {
       return "Battery critical: ${voltage.toStringAsFixed(2)} V - Change battery immediately";
     } else {
       return "Battery low: ${voltage.toStringAsFixed(2)} V - Change battery soon";
@@ -187,7 +195,7 @@ class _VoltageWarningState extends State<VoltageWarning>
       builder: (context, child) => Card(
         color:
             colorAnimation.value ??
-            (isCritical ? Colors.red.shade900 : Colors.yellow.shade800),
+            (_isCritical ? Colors.red.shade900 : Colors.yellow.shade800),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
           child: Row(

--- a/lib/src/widgets/navigation/footer.dart
+++ b/lib/src/widgets/navigation/footer.dart
@@ -133,42 +133,42 @@ class _VoltageWarningState extends State<VoltageWarning>
   }
 
   void checkVoltage() {
-  if (!mounted) return;
+    if (!mounted) return;
 
-  final voltage = widget.model.driveMetrics.batteryVoltage;
-  
-  // Turn on warning when below threshold
-  if (voltage < warningVoltage && voltage > 0) {
-    _isShowing = true;
-  }
-  
-  // Turn off warning when 0.5V above threshold
-  if (voltage > warningVoltage + 0.5 || voltage == 0) {
-    _isShowing = false;
-  }
+    final voltage = widget.model.driveMetrics.batteryVoltage;
 
-  // Turn on critical when below threshold
-  if (voltage < criticalVoltage && voltage > 0) {
-    _isCritical = true;
-  }
-  
-  // Turn off critical when 0.5V above threshold
-  if (voltage > criticalVoltage + 0.5) {
-    _isCritical = false;
-  }
+    // Turn on warning when below threshold
+    if (voltage < warningVoltage && voltage > 0) {
+      _isShowing = true;
+    }
 
-  if (!widget.model.isConnected || !_isShowing) {
-    controller.stop();
-    controller.reset();
-    return;
-  }
+    // Turn off warning when 0.5V above threshold
+    if (voltage > warningVoltage + 0.5 || voltage == 0) {
+      _isShowing = false;
+    }
 
-  updateAnimation();
+    // Turn on critical when below threshold
+    if (voltage < criticalVoltage && voltage > 0) {
+      _isCritical = true;
+    }
 
-  if (!controller.isAnimating) {
-    controller.repeat(reverse: true);
+    // Turn off critical when 0.5V above threshold
+    if (voltage > criticalVoltage + 0.5) {
+      _isCritical = false;
+    }
+
+    if (!widget.model.isConnected || !_isShowing) {
+      controller.stop();
+      controller.reset();
+      return;
+    }
+
+    updateAnimation();
+
+    if (!controller.isAnimating) {
+      controller.repeat(reverse: true);
+    }
   }
-}
 
   @override
   void dispose() {


### PR DESCRIPTION
Fixes flickering when voltage hovers near threshold by adding 0.5V hysteresis buffer.